### PR TITLE
ntils.clone failed to clone typed array and cannot be used by faked to fake protobuf response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -406,6 +406,9 @@ export function clone(src, igonres) {
     isDate(src)) {
     return src;
   }
+  if(isTypedArray(src)){
+    return src.slice();
+  }
   let objClone = src;
   try {
     objClone = new src.constructor();

--- a/src/index.js
+++ b/src/index.js
@@ -238,6 +238,17 @@ export function isArray(obj) {
 }
 
 /**
+ * 验证一个对象是否为typed array
+ * @method isTypedArray
+ * @param  {Object}  obj 要验证的对象
+ * @return {Boolean}     结果
+ * @static
+ */
+export function isTypedArray(obj){
+  return ArrayBuffer.isView(obj) && !(obj instanceof DataView)
+}
+
+/**
  * 验证是不是一个日期对象
  * @method isDate
  * @param {Object} val   要检查的对象


### PR DESCRIPTION
Hi, I really like faked and use it in my project.
However, I found that, if I make a fake protobuf response, I cannot get the proper typed array.
After a bit of work, I found that in faked `core/body`, there's a line written that
`this.rawBody =  utils.clone(rawBody);`

And I found that, utils.clone cannot properly clone typed array. I hope to add this feature, because I need to use protobuf a lot. Thank you very much!